### PR TITLE
ci: publish to npm

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,19 @@
+name: Publish llm-cache to npm
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "faiss-node": "^0.5.0",
     "langchain": "^0.0.154",
     "openai": "^4.10.0"
+  },
+  "scripts": {
+    "build": "tsc"
   }
 }


### PR DESCRIPTION
# What

Publish llm-cache packge to npm
Require setting up a secret named `NPM_TOKEN` to be the npm registry auth token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Set up a new workflow to automatically publish `llm-cache` to npm upon a new release.
	- Automated publishing process on release event using a GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->